### PR TITLE
docs: add daily timeline operating playbook

### DIFF
--- a/.github/ISSUE_TEMPLATE/daily-timeline-update.yml
+++ b/.github/ISSUE_TEMPLATE/daily-timeline-update.yml
@@ -1,0 +1,26 @@
+name: Daily timeline update
+description: Track daily showcase updates for timeline view
+title: "Daily timeline update: YYYY-MM-DD"
+labels: ["coordination"]
+body:
+  - type: input
+    id: date
+    attributes:
+      label: Date
+      placeholder: "2026-03-02"
+    validations:
+      required: true
+  - type: input
+    id: title
+    attributes:
+      label: Milestone title
+      placeholder: "Shipped X"
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: Outcome summary
+      placeholder: "What shipped and why it matters"
+    validations:
+      required: true

--- a/docs/TIMELINE_PLAYBOOK.md
+++ b/docs/TIMELINE_PLAYBOOK.md
@@ -1,0 +1,20 @@
+# Daily Timeline Playbook
+
+Update this every day after key delivery work.
+
+## Where to edit
+- `src/data.timeline.js`
+
+## Entry format
+```js
+{
+  date: 'YYYY-MM-DD',
+  title: 'Short milestone title',
+  summary: '1-2 sentence outcome summary.'
+}
+```
+
+## Rules
+- Add newest entry at the top.
+- Keep entries outcome-focused (what shipped, not just activity).
+- Link to PRs/issues in the summary when relevant.


### PR DESCRIPTION
Adds a lightweight daily process so timeline is updated every day with consistent entries.