### PR TITLE
fix(ci): enforce full-tree critical audit gate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,26 @@
+name: Security Audit
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  npm-audit-critical:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Fail on critical vulnerabilities
+        run: npm audit --audit-level=critical


### PR DESCRIPTION
## Summary
Tighten CI vulnerability gating.

## Changes
- update `.github/workflows/security-audit.yml`
  - fail on critical vulnerabilities across the full dependency tree
  - command now: `npm audit --audit-level=critical`

## Why
Ensures critical vulnerabilities in any installed dependency are blocked in CI.

## Validation
- YAML updated and committed
- Security workflow remains PR/push-triggered on `main`